### PR TITLE
Remove `Mark::TraceRoots`

### DIFF
--- a/src/counter_marker.rs
+++ b/src/counter_marker.rs
@@ -4,8 +4,7 @@ use crate::utils;
 
 const NON_MARKED: u32 = 0u32;
 const IN_POSSIBLE_CYCLES: u32 = 1u32 << (u32::BITS - 3);
-const TRACING_COUNTING_MARKED: u32 = 2u32 << (u32::BITS - 3);
-const TRACING_ROOTS_MARKED: u32 = 3u32 << (u32::BITS - 3);
+const TRACED: u32 = 2u32 << (u32::BITS - 3);
 const INVALID: u32 = 0b111u32 << (u32::BITS - 3);
 
 const COUNTER_MASK: u32 = 0b11111111111111u32; // First 14 bits set to 1
@@ -25,11 +24,10 @@ const MAX: u32 = COUNTER_MASK;
 /// +-----------+----------+------------+------------+
 /// ```
 ///
-/// * `A` has 6 possible states:
+/// * `A` has 4 possible states:
 ///   * `NON_MARKED`
 ///   * `IN_POSSIBLE_CYCLES` (this implies `NON_MARKED`)
-///   * `TRACING_COUNTING_MARKED`
-///   * `TRACING_ROOT_MARKED`
+///   * `TRACED`
 ///   * `INVALID` (`CcOnHeap` is invalid)
 /// * `B` is `1` when the element inside `CcOnHeap` has already been finalized, `0` otherwise
 /// * `C` is the tracing counter
@@ -147,13 +145,8 @@ impl CounterMarker {
     }
 
     #[inline]
-    pub(crate) fn is_marked_trace_counting(&self) -> bool {
-        (self.counter.get() & BITS_MASK) == TRACING_COUNTING_MARKED
-    }
-
-    #[inline]
-    pub(crate) fn is_marked_trace_roots(&self) -> bool {
-        (self.counter.get() & BITS_MASK) == TRACING_ROOTS_MARKED
+    pub(crate) fn is_traced(&self) -> bool {
+        (self.counter.get() & BITS_MASK) == TRACED
     }
 
     #[inline]
@@ -172,7 +165,6 @@ impl CounterMarker {
 pub(crate) enum Mark {
     NonMarked = NON_MARKED,
     PossibleCycles = IN_POSSIBLE_CYCLES,
-    TraceCounting = TRACING_COUNTING_MARKED,
-    TraceRoots = TRACING_ROOTS_MARKED,
+    Traced = TRACED,
     Invalid = INVALID,
 }

--- a/src/tests/cc.rs
+++ b/src/tests/cc.rs
@@ -140,8 +140,6 @@ fn test_cc() {
 #[cfg(feature = "nightly")]
 #[test]
 fn test_trait_object() {
-    use std::mem::ManuallyDrop;
-
     reset_state();
 
     thread_local! {
@@ -196,9 +194,8 @@ fn test_trait_object() {
         let inner = cc.deref();
         inner.hello();
 
-        // Use ManuallyDrop to don't run lists' destructor
-        let mut l1 = ManuallyDrop::new(List::new());
-        let mut l2 = ManuallyDrop::new(List::new());
+        let mut l1 = List::new();
+        let mut l2 = List::new();
 
         cc.trace(&mut Context::new(ContextInner::Counting {
             root_list: &mut l1,

--- a/src/tests/counter_marker.rs
+++ b/src/tests/counter_marker.rs
@@ -12,8 +12,7 @@ fn test_new() {
     fn test(counter: CounterMarker) {
         assert!(counter.is_not_marked());
         assert!(!counter.is_in_possible_cycles());
-        assert!(!counter.is_marked_trace_counting());
-        assert!(!counter.is_marked_trace_roots());
+        assert!(!counter.is_traced());
         assert!(counter.is_valid());
 
         assert_eq!(counter.counter(), 1);
@@ -44,8 +43,7 @@ fn test_increment_decrement() {
         fn assert_not_marked(counter: &CounterMarker) {
             assert!(counter.is_not_marked());
             assert!(!counter.is_in_possible_cycles());
-            assert!(!counter.is_marked_trace_counting());
-            assert!(!counter.is_marked_trace_roots());
+            assert!(!counter.is_traced());
             assert!(counter.is_valid());
         }
 
@@ -122,56 +120,42 @@ fn test_marks() {
     fn test(counter: CounterMarker) {
         assert!(counter.is_not_marked());
         assert!(!counter.is_in_possible_cycles());
-        assert!(!counter.is_marked_trace_counting());
-        assert!(!counter.is_marked_trace_roots());
+        assert!(!counter.is_traced());
         assert!(counter.is_valid());
 
         counter.mark(Mark::NonMarked);
 
         assert!(counter.is_not_marked());
         assert!(!counter.is_in_possible_cycles());
-        assert!(!counter.is_marked_trace_counting());
-        assert!(!counter.is_marked_trace_roots());
+        assert!(!counter.is_traced());
         assert!(counter.is_valid());
 
         counter.mark(Mark::PossibleCycles);
 
         assert!(counter.is_not_marked());
         assert!(counter.is_in_possible_cycles());
-        assert!(!counter.is_marked_trace_counting());
-        assert!(!counter.is_marked_trace_roots());
+        assert!(!counter.is_traced());
         assert!(counter.is_valid());
 
-        counter.mark(Mark::TraceCounting);
+        counter.mark(Mark::Traced);
 
         assert!(!counter.is_not_marked());
         assert!(!counter.is_in_possible_cycles());
-        assert!(counter.is_marked_trace_counting());
-        assert!(!counter.is_marked_trace_roots());
-        assert!(counter.is_valid());
-
-        counter.mark(Mark::TraceRoots);
-
-        assert!(!counter.is_not_marked());
-        assert!(!counter.is_in_possible_cycles());
-        assert!(!counter.is_marked_trace_counting());
-        assert!(counter.is_marked_trace_roots());
+        assert!(counter.is_traced());
         assert!(counter.is_valid());
 
         counter.mark(Mark::NonMarked);
 
         assert!(counter.is_not_marked());
         assert!(!counter.is_in_possible_cycles());
-        assert!(!counter.is_marked_trace_counting());
-        assert!(!counter.is_marked_trace_roots());
+        assert!(!counter.is_traced());
         assert!(counter.is_valid());
 
         counter.mark(Mark::Invalid);
 
         assert!(!counter.is_not_marked());
         assert!(!counter.is_in_possible_cycles());
-        assert!(!counter.is_marked_trace_counting());
-        assert!(!counter.is_marked_trace_roots());
+        assert!(!counter.is_traced());
         assert!(!counter.is_valid());
     }
 

--- a/src/tests/list.rs
+++ b/src/tests/list.rs
@@ -131,7 +131,7 @@ fn test_for_each_clearing_panic() {
 
     for it in &mut vec {
         unsafe {
-            it.as_ref().counter_marker().mark(Mark::TraceCounting); // Just a random mark
+            it.as_ref().counter_marker().mark(Mark::PossibleCycles); // Just a random mark
         }
     }
 
@@ -188,7 +188,7 @@ fn test_mark_self_and_append() {
     let vec_to_append = new_list(&elements_to_append, &mut to_append);
 
     list.iter().for_each(|elem| unsafe {
-        elem.as_ref().counter_marker().mark(Mark::TraceRoots);
+        elem.as_ref().counter_marker().mark(Mark::Traced);
     });
     to_append.iter().for_each(|elem| unsafe {
         elem.as_ref().counter_marker().mark(Mark::PossibleCycles);
@@ -216,7 +216,7 @@ fn test_mark_self_and_append_empty_list() {
     let vec = new_list(&elements, &mut list);
 
     list.iter().for_each(|elem| unsafe {
-        elem.as_ref().counter_marker().mark(Mark::TraceRoots);
+        elem.as_ref().counter_marker().mark(Mark::Traced);
     });
 
     list.mark_self_and_append(Mark::PossibleCycles, to_append);

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -182,6 +182,7 @@ pub(crate) enum ContextInner<'a> {
         non_root_list: &'a mut List,
     },
     RootTracing {
+        root_list: &'a mut List,
         non_root_list: &'a mut List,
     },
 }


### PR DESCRIPTION
This removes `Mark::TraceRoots` (and renames `Mark::TraceCounting` to `Mark::Traced`), since it isn't really needed.