### PR TITLE
 Update to 0.4.0

### DIFF
--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -7,7 +7,7 @@ env:
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
 
 jobs:
-  test-with-miri:
+  test-with-miri-stable:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -24,5 +24,19 @@ jobs:
       - name: Run tests
         # Keep "std" feature always enabled here to avoid needing the no-std related nightly features
         run: cargo hack miri test --feature-powerset --skip nightly,derive --verbose -F std,pedantic-debug-assertions
+  test-with-miri-nightly:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      # From Miri documentation: https://github.com/rust-lang/miri#running-miri-on-ci
+      - name: Install Miri
+        run: |
+          rustup toolchain install nightly --component miri
+          rustup override set nightly
+          cargo miri setup
+      - uses: taiki-e/install-action@cargo-hack
+      # Always skip "derive" since derive macro tests are skipped on Miri
+      # Also always keep "pedantic-debug-assertions" enabled to reduce build times
+      # Note: no need to use --workspace here, since there's no unsafe in rust-cc-derive
       - name: Run tests (nightly)
         run: cargo hack miri test --feature-powerset --skip derive --verbose -F nightly,pedantic-debug-assertions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,13 @@ Therefore, they undergo two tracing passes:
   Note that this second phase is correct only if the graph formed by the pointers is not changed between the two phases. Thus,
   this is a key requirement of the `Trace` trait and one of the reasons it is marked `unsafe`.
 
-# Writing documentation
+## Writing tests
+
+Every unit test should start with a call to `tests::reset_state()` to make sure errors in other tests don't impact the current one.
+
+Also, functions marked as `pub(crate)` and used only in unit tests should have the `for_tests` suffix, like `Cc::new_for_tests`.
+
+## Writing documentation
 
 Docs are always built with every feature enabled. This makes it easier to write and maintain the documentation.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,9 @@ name = "bench"
 harness = false
 required-features = ["std", "derive"]
 
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(doc_auto_cfg)'] }
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "doc_auto_cfg", "--generate-link-to-definition"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition.workspace = true
 members = ["derive"]
 
 [workspace.package]
-version = "0.3.0" # Also update in [dependencies.rust-cc-derive.version]
+version = "0.4.0" # Also update in [dependencies.rust-cc-derive.version]
 authors = ["fren_gor <goro@frengor.com>"]
 repository = "https://github.com/frengor/rust-cc"
 categories = ["memory-management", "no-std"]
@@ -49,7 +49,7 @@ std = ["slotmap?/std", "thiserror/std"]
 pedantic-debug-assertions = []
 
 [dependencies]
-rust-cc-derive = { path = "./derive", version = "=0.3.0", optional = true }
+rust-cc-derive = { path = "./derive", version = "=0.4.0", optional = true }
 slotmap = {  version = "1.0", optional = true }
 thiserror = { version = "1.0", package = "thiserror-core", default-features = false }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,10 +37,10 @@ auto-collect = []
 finalization = []
 
 # Enables weak pointers
-weak-ptr = []
+weak-ptrs = []
 
 # Enables cleaners
-cleaners = ["dep:slotmap", "weak-ptr"]
+cleaners = ["dep:slotmap", "weak-ptrs"]
 
 # Enables support for stdlib, disable for no-std support (requires ELF TLS and nightly)
 std = ["slotmap?/std", "thiserror/std"]

--- a/README.md
+++ b/README.md
@@ -63,11 +63,6 @@ impl Finalize for Data {
 }
 ```
 
-> [!NOTE]  
-> Finalization adds an overhead to each collection execution. Cleaners provide a faster alternative to finalization.
->
-> *When possible*, it's suggested to prefer cleaners and disable finalization.
-
 For more information read [the docs](https://docs.rs/rust-cc/latest/rust_cc/).
 
 ## The collection algorithm

--- a/src/cc.rs
+++ b/src/cc.rs
@@ -62,7 +62,7 @@ impl<T: Trace + 'static> Cc<T> {
             }
 
             #[cfg(feature = "auto-collect")]
-            super::trigger_collection();
+            super::trigger_collection(state);
 
             Cc {
                 inner: CcBox::new(t, state),

--- a/src/cc.rs
+++ b/src/cc.rs
@@ -56,7 +56,6 @@ impl<T: Trace> Cc<T> {
     /// # Panics
     /// 
     /// Panics if the automatically-stared collection panics.
-    #[inline(always)]
     #[must_use = "newly created Cc is immediately dropped"]
     #[track_caller]
     pub fn new(t: T) -> Cc<T> {
@@ -353,7 +352,6 @@ pub(crate) struct CcBox<T: ?Sized + Trace + 'static> {
 }
 
 impl<T: Trace> CcBox<T> {
-    #[inline(always)]
     #[must_use]
     fn new(t: T, state: &State) -> NonNull<CcBox<T>> {
         let layout = Layout::new::<CcBox<T>>();
@@ -380,7 +378,6 @@ impl<T: Trace> CcBox<T> {
         }
     }
 
-    #[inline(always)]
     #[cfg(all(test, feature = "std"))] // Only used in unit tests
     #[must_use]
     pub(crate) fn new_for_tests(t: T) -> NonNull<CcBox<T>> {
@@ -853,7 +850,7 @@ impl<T: Trace> From<T> for Cc<T> {
     /// This method may start a collection when the `auto-collect` feature is enabled.
     ///
     /// See the [`config` module documentation][`mod@crate::config`] for more details.
-    #[inline(always)]
+    #[inline]
     fn from(value: T) -> Self {
         Cc::new(value)
     }

--- a/src/cleaners/mod.rs
+++ b/src/cleaners/mod.rs
@@ -110,7 +110,7 @@ unsafe impl Trace for Cleaner {
     fn trace(&self, _: &mut Context<'_>) {
         // DO NOT TRACE self.cleaner_map, it would be unsound!
         // If self.cleaner_map would be traced here, it would be possible to have cleaning actions called
-        // with a reference to the cleaned object accessible from inside the clean function.
+        // with a reference to the cleaned object accessible from inside the cleaning action itself.
         // This would be unsound, since cleaning actions are called from the Drop implementation of Ccs (see the Trace trait safety section)
     }
 }

--- a/src/cleaners/mod.rs
+++ b/src/cleaners/mod.rs
@@ -16,7 +16,7 @@
 //! 
 //! # Avoiding memory leaks
 //! 
-//! Usually, [`Cleaner`]s are stored inside a cycle-collected object. Make sure to **never capture** a reference to the containing object
+//! Usually, [`Cleaner`]s are stored inside a cycle-collected object. Make sure to **never capture** a reference to the container object
 //! inside the cleaning action closure, otherwise the object will be leaked and the cleaning action will never be executed.
 //! 
 //! # Cleaners vs finalization
@@ -83,7 +83,7 @@ impl Cleaner {
     ///
     /// # Avoiding memory leaks
     /// Usually, [`Cleaner`]s are stored inside a cycle-collected object. Make sure to **never capture**
-    /// a reference to the containing object inside the `action` closure, otherwise the object will
+    /// a reference to the container object inside the `action` closure, otherwise the object will
     /// be leaked and the cleaning action will never be executed.
     #[inline]
     pub fn register(&self, action: impl FnOnce() + 'static) -> Cleanable {

--- a/src/cleaners/mod.rs
+++ b/src/cleaners/mod.rs
@@ -29,8 +29,8 @@ use core::cell::RefCell;
 
 use slotmap::{new_key_type, SlotMap};
 
-use crate::{Context, Finalize, Trace};
-use crate::weak::{Weak, WeakableCc};
+use crate::{Cc, Context, Finalize, Trace};
+use crate::weak::Weak;
 
 new_key_type! {
     struct CleanerKey;
@@ -62,7 +62,7 @@ impl Drop for CleanerFn {
 ///
 /// All the cleaning actions registered in a `Cleaner` are run when it is dropped, unless they have been manually executed before.
 pub struct Cleaner {
-    cleaner_map: WeakableCc<CleanerMap>,
+    cleaner_map: Cc<CleanerMap>,
 }
 
 impl Cleaner {
@@ -71,7 +71,7 @@ impl Cleaner {
     #[inline]
     pub fn new() -> Cleaner {
         Cleaner {
-            cleaner_map: WeakableCc::new_weakable(CleanerMap {
+            cleaner_map: Cc::new(CleanerMap {
                 map: RefCell::new(None),
             }),
         }

--- a/src/counter_marker.rs
+++ b/src/counter_marker.rs
@@ -136,19 +136,19 @@ impl CounterMarker {
         self.set_bit(finalized, FINALIZED_MASK);
     }
 
-    #[cfg(feature = "weak-ptr")]
+    #[cfg(feature = "weak-ptrs")]
     #[inline]
     pub(crate) fn has_allocated_for_metadata(&self) -> bool {
         (self.counter.get() & METADATA_MASK) == METADATA_MASK
     }
 
-    #[cfg(feature = "weak-ptr")]
+    #[cfg(feature = "weak-ptrs")]
     #[inline]
     pub(crate) fn set_allocated_for_metadata(&self, allocated_for_metadata: bool) {
         self.set_bit(allocated_for_metadata, METADATA_MASK);
     }
 
-    #[cfg(any(feature = "weak-ptr", feature = "finalization"))]
+    #[cfg(any(feature = "weak-ptrs", feature = "finalization"))]
     #[inline(always)]
     fn set_bit(&self, value: bool, mask: u32) {
         if value {
@@ -177,7 +177,7 @@ impl CounterMarker {
         (self.counter.get() & FIRST_BIT_MASK) == FIRST_BIT_MASK
     }
 
-    #[cfg(any(feature = "weak-ptr", all(test, feature = "std")))]
+    #[cfg(any(feature = "weak-ptrs", all(test, feature = "std")))]
     #[inline]
     pub(crate) fn is_dropped(&self) -> bool {
         (self.counter.get() & BITS_MASK) == DROPPED

--- a/src/counter_marker.rs
+++ b/src/counter_marker.rs
@@ -5,12 +5,14 @@ use crate::utils;
 const NON_MARKED: u32 = 0u32;
 const IN_POSSIBLE_CYCLES: u32 = 1u32 << (u32::BITS - 2);
 const TRACED: u32 = 2u32 << (u32::BITS - 2);
+#[allow(dead_code)] // Used only in weak ptrs, silence warnings
+const DROPPED: u32 = 3u32 << (u32::BITS - 2);
 
 const COUNTER_MASK: u32 = 0b11111111111111u32; // First 14 bits set to 1
 const TRACING_COUNTER_MASK: u32 = COUNTER_MASK << 14; // 14 bits set to 1 followed by 14 bits set to 0
 const FINALIZED_MASK: u32 = 1u32 << (u32::BITS - 4);
-const DROPPED_MASK: u32 = 1u32 << (u32::BITS - 3);
-const BITS_MASK: u32 = !(COUNTER_MASK | TRACING_COUNTER_MASK | FINALIZED_MASK | DROPPED_MASK);
+const METADATA_MASK: u32 = 1u32 << (u32::BITS - 3);
+const BITS_MASK: u32 = !(COUNTER_MASK | TRACING_COUNTER_MASK | FINALIZED_MASK | METADATA_MASK);
 const FIRST_BIT_MASK: u32 = 1u32 << (u32::BITS - 1);
 
 const INITIAL_VALUE: u32 = COUNTER_MASK + 2; // +2 means that tracing counter and counter are both set to 1
@@ -26,11 +28,12 @@ pub(crate) const MAX: u32 = COUNTER_MASK;
 /// +-----------+----------+----------+------------+------------+
 /// ```
 ///
-/// * `A` has 3 possible states:
+/// * `A` has 4 possible states:
 ///   * `NON_MARKED`
-///   * `IN_POSSIBLE_CYCLES` (this implies `NON_MARKED`)
-///   * `TRACED`
-/// * `B` is `1` when the element inside `CcBox` has already been dropped, `0` otherwise
+///   * `IN_POSSIBLE_CYCLES`: in `possible_cycles` list (implies `NON_MARKED`)
+///   * `TRACED`: in `root_list` or `non_root_list`
+///   * `DROPPED`: allocated value has already been dropped (but not yet deallocated)
+/// * `B` is `1` when metadata has been allocated, `0` otherwise
 /// * `C` is `1` when the element inside `CcBox` has already been finalized, `0` otherwise
 /// * `D` is the tracing counter
 /// * `E` is the counter (last one for sum/subtraction efficiency)
@@ -135,14 +138,14 @@ impl CounterMarker {
 
     #[cfg(feature = "weak-ptr")]
     #[inline]
-    pub(crate) fn is_dropped(&self) -> bool {
-        (self.counter.get() & DROPPED_MASK) == DROPPED_MASK
+    pub(crate) fn has_allocated_for_metadata(&self) -> bool {
+        (self.counter.get() & METADATA_MASK) == METADATA_MASK
     }
 
     #[cfg(feature = "weak-ptr")]
     #[inline]
-    pub(crate) fn set_dropped(&self, dropped: bool) {
-        self.set_bit(dropped, DROPPED_MASK);
+    pub(crate) fn set_allocated_for_metadata(&self, allocated_for_metadata: bool) {
+        self.set_bit(allocated_for_metadata, METADATA_MASK);
     }
 
     #[cfg(any(feature = "weak-ptr", feature = "finalization"))]
@@ -168,6 +171,19 @@ impl CounterMarker {
     }
 
     #[inline]
+    pub(crate) fn is_traced_or_dropped(&self) -> bool {
+        // true if (self.counter & BITS_MASK) is equal to 10 or 11,
+        // so if the first bit is 1
+        (self.counter.get() & FIRST_BIT_MASK) == FIRST_BIT_MASK
+    }
+
+    #[cfg(any(feature = "weak-ptr", all(test, feature = "std")))]
+    #[inline]
+    pub(crate) fn is_dropped(&self) -> bool {
+        (self.counter.get() & BITS_MASK) == DROPPED
+    }
+
+    #[inline]
     pub(crate) fn mark(&self, new_mark: Mark) {
         self.counter.set((self.counter.get() & !BITS_MASK) | (new_mark as u32));
     }
@@ -179,4 +195,6 @@ pub(crate) enum Mark {
     NonMarked = NON_MARKED,
     PossibleCycles = IN_POSSIBLE_CYCLES,
     Traced = TRACED,
+    #[allow(dead_code)] // Used only in weak ptrs, silence warnings
+    Dropped = DROPPED,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,19 +210,17 @@ pub fn collect_cycles() {
 
 #[cfg(feature = "auto-collect")]
 #[inline(never)]
-pub(crate) fn trigger_collection() {
-    let _ = try_state(|state| {
-        if state.is_collecting() {
-            return;
+pub(crate) fn trigger_collection(state: &State) {
+    if state.is_collecting() {
+        return;
+    }
+
+    let _ = POSSIBLE_CYCLES.try_with(|pc| {
+        if config::config(|config| config.should_collect(state, pc)).unwrap_or(false) {
+            collect(state, pc);
+
+            adjust_trigger_point(state);
         }
-
-        let _ = POSSIBLE_CYCLES.try_with(|pc| {
-            if config::config(|config| config.should_collect(state, pc)).unwrap_or(false) {
-                collect(state, pc);
-
-                adjust_trigger_point(state);
-            }
-        });
     });
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,11 +64,11 @@ collect_cycles();
 //! ### Weak pointers
 //!
 #![cfg_attr(
-    feature = "weak-ptr",
+    feature = "weak-ptrs",
     doc = r"```rust"
 )]
 #![cfg_attr(
-    not(feature = "weak-ptr"),
+    not(feature = "weak-ptrs"),
     doc = r"```rust,ignore"
 )]
 #![doc = r"# use rust_cc::*;
@@ -174,7 +174,7 @@ pub mod config;
 #[cfg(feature = "derive")]
 mod derives;
 
-#[cfg(feature = "weak-ptr")]
+#[cfg(feature = "weak-ptrs")]
 pub mod weak;
 
 #[cfg(feature = "cleaners")]
@@ -395,14 +395,14 @@ fn deallocate_list(to_deallocate_list: List, state: &State) {
         fn drop(&mut self) {
             // Remove the elements from the list, setting them as dropped
             // This feature is used only in weak pointers, so do this only if they're enabled
-            #[cfg(feature = "weak-ptr")]
+            #[cfg(feature = "weak-ptrs")]
             while let Some(ptr) = self.list.remove_first() {
                 // Always set the mark, since it has been cleared by remove_first
                 unsafe { ptr.as_ref() }.counter_marker().mark(Mark::Dropped);
             }
 
             // If not using weak pointers, just call the list's drop implementation
-            #[cfg(not(feature = "weak-ptr"))]
+            #[cfg(not(feature = "weak-ptrs"))]
             unsafe {
                 ManuallyDrop::drop(&mut self.list);
             }
@@ -422,7 +422,7 @@ fn deallocate_list(to_deallocate_list: List, state: &State) {
         unsafe {
             debug_assert!(ptr.as_ref().counter_marker().is_traced());
 
-            #[cfg(feature = "weak-ptr")]
+            #[cfg(feature = "weak-ptrs")]
             ptr.as_ref().drop_metadata();
 
             CcBox::drop_inner(ptr.cast());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,7 +138,6 @@ cleanable.clean();
 
 #![deny(rustdoc::broken_intra_doc_links)]
 #![allow(clippy::thread_local_initializer_can_be_made_const)]
-#![allow(unexpected_cfgs)]
 
 #[cfg(all(not(feature = "std"), not(feature = "nightly")))]
 compile_error!("Feature \"std\" cannot be disabled without enabling feature \"nightly\" (due to #[thread_local] not being stable).");

--- a/src/tests/counter_marker.rs
+++ b/src/tests/counter_marker.rs
@@ -52,7 +52,7 @@ fn test_is_to_finalize() {
     assert!(counter.needs_finalization());
 }
 
-#[cfg(feature = "weak-ptr")]
+#[cfg(feature = "weak-ptrs")]
 #[test]
 fn test_weak_ptrs_exists() {
     let counter = CounterMarker::new_with_counter_to_one(false);

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -15,7 +15,7 @@ mod list;
 mod panicking;
 mod counter_marker;
 
-#[cfg(feature = "weak-ptr")]
+#[cfg(feature = "weak-ptrs")]
 mod weak;
 
 #[cfg(feature = "cleaners")]

--- a/src/tests/weak/mod.rs
+++ b/src/tests/weak/mod.rs
@@ -149,7 +149,8 @@ fn test_new_cyclic() {
 fn panicking_new_cyclic1() {
     reset_state();
 
-    let _cc = Cc::new_cyclic(|_| {
+    #[allow(clippy::unused_unit)] // Unit type needed to fix never type fallback error
+    let _cc = Cc::new_cyclic(|_| -> () {
         panic!("Expected panic during panicking_new_cyclic1!");
     });
 }
@@ -159,7 +160,8 @@ fn panicking_new_cyclic1() {
 fn panicking_new_cyclic2() {
     reset_state();
 
-    let _cc = Cc::new_cyclic(|weak| {
+    #[allow(clippy::unused_unit)] // Unit type needed to fix never type fallback error
+    let _cc = Cc::new_cyclic(|weak| -> () {
         let _weak = weak.clone();
         panic!("Expected panic during panicking_new_cyclic2!");
     });

--- a/src/tests/weak/mod.rs
+++ b/src/tests/weak/mod.rs
@@ -374,3 +374,41 @@ fn try_upgrade_in_cyclic_finalize_and_drop() {
     }
     assert!(DROPPED.with(|dropped| dropped.get()));
 }
+
+#[test]
+fn weak_new() {
+    reset_state();
+    
+    let new: Weak<u32> = Weak::new();
+
+    assert_eq!(0, new.weak_count());
+    assert_eq!(0, new.strong_count());
+    assert!(new.upgrade().is_none());
+
+    let other = new.clone();
+
+    assert_eq!(0, other.weak_count());
+    assert_eq!(0, other.strong_count());
+    assert!(other.upgrade().is_none());
+}
+
+#[test]
+fn weak_new_ptr_eq() {
+    reset_state();
+    
+    let new: Weak<u32> = Weak::new();
+    let other_new: Weak<u32> = Weak::new();
+    
+    let cc = Cc::new(5u32);
+    let other_cc = Cc::new(6u32);
+
+    assert_eq!(0, new.weak_count());
+    assert_eq!(0, new.strong_count());
+
+    assert!(Weak::ptr_eq(&new, &new));
+    assert!(Weak::ptr_eq(&new, &other_new));
+    assert!(Weak::ptr_eq(&new, &new.clone()));
+    assert!(!Weak::ptr_eq(&new, &cc.downgrade()));
+    assert!(Weak::ptr_eq(&cc.downgrade(), &cc.downgrade()));
+    assert!(!Weak::ptr_eq(&cc.downgrade(), &other_cc.downgrade()));
+}

--- a/src/tests/weak/mod.rs
+++ b/src/tests/weak/mod.rs
@@ -1,9 +1,8 @@
 use std::cell::Cell;
-use std::ops::Deref;
 use std::panic::catch_unwind;
 use crate::*;
 use super::reset_state;
-use crate::weak::{Weak, Weakable, WeakableCc};
+use crate::weak::Weak;
 
 #[test]
 fn weak_test() {
@@ -44,22 +43,22 @@ fn weak_test2() {
     collect_cycles();
 }
 
-fn weak_test_common() -> (WeakableCc<i32>, Weak<i32>) {
+fn weak_test_common() -> (Cc<i32>, Weak<i32>) {
     reset_state();
 
-    let cc: Cc<Weakable<i32>> = WeakableCc::new_weakable(0i32);
+    let cc: Cc<i32> = Cc::new(0i32);
 
-    assert!(!cc.deref().has_allocated());
+    assert!(!cc.inner().counter_marker().has_allocated_for_metadata());
     assert_eq!(0, cc.weak_count());
     assert_eq!(1, cc.strong_count());
 
     let cc1 = cc.clone();
 
-    assert!(!cc.deref().has_allocated());
+    assert!(!cc.inner().counter_marker().has_allocated_for_metadata());
 
     let weak = cc.downgrade();
 
-    assert!(cc.deref().has_allocated());
+    assert!(cc.inner().counter_marker().has_allocated_for_metadata());
 
     assert_eq!(2, cc.strong_count());
     assert_eq!(1, weak.weak_count());
@@ -103,8 +102,8 @@ fn weak_test_common() -> (WeakableCc<i32>, Weak<i32>) {
 fn weak_dst() {
     reset_state();
 
-    let cc = Cc::new_weakable(0i32);
-    let cc1: WeakableCc<dyn Trace> = cc.clone();
+    let cc = Cc::new(0i32);
+    let cc1: Cc<dyn Trace> = cc.clone();
     let _weak: Weak<dyn Trace> = cc.downgrade();
     let _weak1: Weak<dyn Trace> = cc1.downgrade();
 }
@@ -136,7 +135,7 @@ fn test_new_cyclic() {
         }
     });
 
-    assert!(cyclic.deref().has_allocated());
+    assert!(cyclic.inner().counter_marker().has_allocated_for_metadata());
 
     assert_eq!(1, cyclic.weak_count());
     assert_eq!(1, cyclic.strong_count());
@@ -270,7 +269,7 @@ fn try_upgrade_and_resurrect_in_finalize_and_drop() {
     reset_state();
 
     thread_local! {
-        static RESURRECTED: Cell<Option<WeakableCc<Cyclic>>> = Cell::new(None);
+        static RESURRECTED: Cell<Option<Cc<Cyclic>>> = Cell::new(None);
     }
 
     struct Cyclic {
@@ -322,7 +321,7 @@ fn try_upgrade_in_cyclic_finalize_and_drop() {
     }
 
     struct Cyclic {
-        cyclic: RefCell<Option<WeakableCc<Cyclic>>>,
+        cyclic: RefCell<Option<Cc<Cyclic>>>,
         weak: Weak<Cyclic>,
     }
 
@@ -349,7 +348,7 @@ fn try_upgrade_in_cyclic_finalize_and_drop() {
     }
 
     let weak: Weak<Cyclic> = {
-        let cc: Cc<Weakable<Cyclic>> = WeakableCc::new_cyclic(|weak| Cyclic {
+        let cc: Cc<Cyclic> = Cc::new_cyclic(|weak| Cyclic {
             cyclic: RefCell::new(None),
             weak: weak.clone(),
         });

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -310,7 +310,7 @@ deref_traces_sized! {
 unsafe impl<T: ?Sized + Trace> Trace for RefCell<T> {
     #[inline]
     fn trace(&self, ctx: &mut Context<'_>) {
-        if let Ok(borrow) = self.try_borrow() {
+        if let Ok(borrow) = self.try_borrow_mut() {
             borrow.trace(ctx);
         }
     }

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -253,16 +253,16 @@ impl<T> Finalize for MaybeUninit<T> {
     fn finalize(&self) {}
 }*/
 
-unsafe impl<T> Trace for PhantomData<T> {
+unsafe impl<T: ?Sized> Trace for PhantomData<T> {
     #[inline(always)]
     fn trace(&self, _: &mut Context<'_>) {}
 }
 
-impl<T> Finalize for PhantomData<T> {}
+impl<T: ?Sized> Finalize for PhantomData<T> {}
 
 macro_rules! deref_trace {
     ($generic:ident; $this:ty; $($bound:tt)*) => {
-        unsafe impl<$generic: $($bound)* $crate::trace::Trace + 'static> $crate::trace::Trace for $this
+        unsafe impl<$generic: $($bound)* $crate::trace::Trace> $crate::trace::Trace for $this
         {
             #[inline]
             fn trace(&self, ctx: &mut $crate::trace::Context<'_>) {
@@ -271,7 +271,7 @@ macro_rules! deref_trace {
             }
         }
 
-        impl<$generic: $($bound)* $crate::trace::Finalize + 'static> $crate::trace::Finalize for $this
+        impl<$generic: $($bound)* $crate::trace::Finalize> $crate::trace::Finalize for $this
         {
             #[inline]
             fn finalize(&self) {
@@ -307,7 +307,7 @@ deref_traces_sized! {
     AssertUnwindSafe,
 }
 
-unsafe impl<T: ?Sized + Trace + 'static> Trace for RefCell<T> {
+unsafe impl<T: ?Sized + Trace> Trace for RefCell<T> {
     #[inline]
     fn trace(&self, ctx: &mut Context<'_>) {
         if let Ok(borrow) = self.try_borrow() {
@@ -316,7 +316,7 @@ unsafe impl<T: ?Sized + Trace + 'static> Trace for RefCell<T> {
     }
 }
 
-impl<T: ?Sized + Finalize + 'static> Finalize for RefCell<T> {
+impl<T: ?Sized + Finalize> Finalize for RefCell<T> {
     #[inline]
     fn finalize(&self) {
         if let Ok(borrow) = self.try_borrow() {
@@ -325,7 +325,7 @@ impl<T: ?Sized + Finalize + 'static> Finalize for RefCell<T> {
     }
 }
 
-unsafe impl<T: Trace + 'static> Trace for Option<T> {
+unsafe impl<T: Trace> Trace for Option<T> {
     #[inline]
     fn trace(&self, ctx: &mut Context<'_>) {
         if let Some(inner) = self {
@@ -334,7 +334,7 @@ unsafe impl<T: Trace + 'static> Trace for Option<T> {
     }
 }
 
-impl<T: Finalize + 'static> Finalize for Option<T> {
+impl<T: Finalize> Finalize for Option<T> {
     #[inline]
     fn finalize(&self) {
         if let Some(value) = self {
@@ -343,7 +343,7 @@ impl<T: Finalize + 'static> Finalize for Option<T> {
     }
 }
 
-unsafe impl<R: Trace + 'static, E: Trace + 'static> Trace for Result<R, E> {
+unsafe impl<R: Trace, E: Trace> Trace for Result<R, E> {
     #[inline]
     fn trace(&self, ctx: &mut Context<'_>) {
         match self {
@@ -353,7 +353,7 @@ unsafe impl<R: Trace + 'static, E: Trace + 'static> Trace for Result<R, E> {
     }
 }
 
-impl<R: Finalize + 'static, E: Finalize + 'static> Finalize for Result<R, E> {
+impl<R: Finalize, E: Finalize> Finalize for Result<R, E> {
     #[inline]
     fn finalize(&self) {
         match self {
@@ -363,7 +363,7 @@ impl<R: Finalize + 'static, E: Finalize + 'static> Finalize for Result<R, E> {
     }
 }
 
-unsafe impl<T: Trace + 'static, const N: usize> Trace for [T; N] {
+unsafe impl<T: Trace, const N: usize> Trace for [T; N] {
     #[inline]
     fn trace(&self, ctx: &mut Context<'_>) {
         for elem in self {
@@ -372,7 +372,7 @@ unsafe impl<T: Trace + 'static, const N: usize> Trace for [T; N] {
     }
 }
 
-impl<T: Finalize + 'static, const N: usize> Finalize for [T; N] {
+impl<T: Finalize, const N: usize> Finalize for [T; N] {
     #[inline]
     fn finalize(&self) {
         for elem in self {
@@ -381,7 +381,7 @@ impl<T: Finalize + 'static, const N: usize> Finalize for [T; N] {
     }
 }
 
-unsafe impl<T: Trace + 'static> Trace for [T] {
+unsafe impl<T: Trace> Trace for [T] {
     #[inline]
     fn trace(&self, ctx: &mut Context<'_>) {
         for elem in self {
@@ -390,7 +390,7 @@ unsafe impl<T: Trace + 'static> Trace for [T] {
     }
 }
 
-impl<T: Finalize + 'static> Finalize for [T] {
+impl<T: Finalize> Finalize for [T] {
     #[inline]
     fn finalize(&self) {
         for elem in self {
@@ -399,7 +399,7 @@ impl<T: Finalize + 'static> Finalize for [T] {
     }
 }
 
-unsafe impl<T: Trace + 'static> Trace for Vec<T> {
+unsafe impl<T: Trace> Trace for Vec<T> {
     #[inline]
     fn trace(&self, ctx: &mut Context<'_>) {
         for elem in self {
@@ -408,7 +408,7 @@ unsafe impl<T: Trace + 'static> Trace for Vec<T> {
     }
 }
 
-impl<T: Finalize + 'static> Finalize for Vec<T> {
+impl<T: Finalize> Finalize for Vec<T> {
     #[inline]
     fn finalize(&self) {
         for elem in self {
@@ -421,7 +421,7 @@ macro_rules! tuple_finalize_trace {
     ($($args:ident),+) => {
         #[allow(non_snake_case)]
         unsafe impl<$($args),*> $crate::trace::Trace for ($($args,)*)
-        where $($args: $crate::trace::Trace + 'static),*
+        where $($args: $crate::trace::Trace),*
         {
             #[inline]
             fn trace(&self, ctx: &mut $crate::trace::Context<'_>) {
@@ -437,7 +437,7 @@ macro_rules! tuple_finalize_trace {
 
         #[allow(non_snake_case)]
         impl<$($args),*> $crate::trace::Finalize for ($($args,)*)
-        where $($args: $crate::trace::Finalize + 'static),*
+        where $($args: $crate::trace::Finalize),*
         {
             #[inline]
             fn finalize(&self) {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -95,7 +95,7 @@ mod no_std_thread_locals {
         value: T,
     }
 
-    impl<T: 'static> NoStdLocalKey<T> {
+    impl<T> NoStdLocalKey<T> {
         #[inline(always)]
         pub(crate) const fn new(value: T) -> Self {
             NoStdLocalKey { value }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -23,7 +23,7 @@ pub(crate) unsafe fn cc_dealloc<T: ?Sized + Trace + 'static>(
     dealloc(ptr.cast().as_ptr(), layout);
 }
 
-#[cfg(any(feature = "weak-ptr", feature = "cleaners"))]
+#[cfg(any(feature = "weak-ptrs", feature = "cleaners"))]
 #[inline]
 pub(crate) unsafe fn alloc_other<T>() -> NonNull<T> {
     let layout = Layout::new::<T>();
@@ -33,7 +33,7 @@ pub(crate) unsafe fn alloc_other<T>() -> NonNull<T> {
     }
 }
 
-#[cfg(any(feature = "weak-ptr", feature = "cleaners"))]
+#[cfg(any(feature = "weak-ptrs", feature = "cleaners"))]
 #[inline]
 pub(crate) unsafe fn dealloc_other<T>(ptr: NonNull<T>) {
     let layout = Layout::new::<T>();

--- a/src/weak/mod.rs
+++ b/src/weak/mod.rs
@@ -37,7 +37,7 @@ impl<T, U> CoerceUnsized<Weak<U>> for Weak<T>
 {
 }
 
-impl<T: Trace + 'static> Weak<T> {
+impl<T: Trace> Weak<T> {
     /// Constructs a new [`Weak<T>`][`Weak`], without allocating any memory. Calling [`upgrade`][`method@Weak::upgrade`] on the returned value always gives [`None`].
     #[inline]
     pub fn new() -> Self {
@@ -49,7 +49,7 @@ impl<T: Trace + 'static> Weak<T> {
     }
 }
 
-impl<T: ?Sized + Trace + 'static> Weak<T> {
+impl<T: ?Sized + Trace> Weak<T> {
     /// Tries to upgrade the weak pointer to a [`Cc`], returning [`None`] if the allocation has already been deallocated.
     /// 
     /// This creates a [`Cc`] pointer to the managed allocation, increasing the strong reference count.
@@ -139,7 +139,7 @@ impl<T: ?Sized + Trace + 'static> Weak<T> {
     }
 }
 
-impl<T: ?Sized + Trace + 'static> Clone for Weak<T> {
+impl<T: ?Sized + Trace> Clone for Weak<T> {
     /// Makes a clone of the [`Weak`] pointer.
     /// 
     /// This creates another [`Weak`] pointer to the same allocation, increasing the weak reference count.
@@ -169,7 +169,7 @@ impl<T: ?Sized + Trace + 'static> Clone for Weak<T> {
     }
 }
 
-impl<T: ?Sized + Trace + 'static> Drop for Weak<T> {
+impl<T: ?Sized + Trace> Drop for Weak<T> {
     #[inline]
     fn drop(&mut self) {
         let Some(metadata) = self.metadata else { return; };
@@ -187,24 +187,24 @@ impl<T: ?Sized + Trace + 'static> Drop for Weak<T> {
     }
 }
 
-unsafe impl<T: ?Sized + Trace + 'static> Trace for Weak<T> {
+unsafe impl<T: ?Sized + Trace> Trace for Weak<T> {
     #[inline(always)]
     fn trace(&self, _: &mut Context<'_>) {
         // Do not trace anything here, otherwise it wouldn't be a weak pointer
     }
 }
 
-impl<T: ?Sized + Trace + 'static> Finalize for Weak<T> {
+impl<T: ?Sized + Trace> Finalize for Weak<T> {
 }
 
-impl<T: Trace + 'static> Default for Weak<T> {
+impl<T: Trace> Default for Weak<T> {
     #[inline]
     fn default() -> Self {
         Weak::new()
     }
 }
 
-impl<T: Trace + 'static> Cc<T> {
+impl<T: Trace> Cc<T> {
     /// Creates a new [`Cc<T>`][`Cc`] while providing a [`Weak<T>`][`Weak`] pointer to the allocation,
     /// to allow the creation of a `T` which holds a weak pointer to itself.
     /// 
@@ -288,7 +288,7 @@ let cyclic = Cc::new_cyclic(|weak| {
             invalid_cc: NonNull<CcBox<NewCyclicWrapper<T>>>,
         }
 
-        impl<T: Trace + 'static> Drop for PanicGuard<T> {
+        impl<T: Trace> Drop for PanicGuard<T> {
             fn drop(&mut self) {
                 unsafe {
                     // Deallocate only the metadata allocation
@@ -327,7 +327,7 @@ let cyclic = Cc::new_cyclic(|weak| {
     }
 }
 
-impl<T: ?Sized + Trace + 'static> Cc<T> {
+impl<T: ?Sized + Trace> Cc<T> {
     /// Creates a new [`Weak`] pointer to the managed allocation, increasing the weak reference count.
     /// 
     /// # Panics
@@ -376,7 +376,7 @@ struct NewCyclicWrapper<T: Trace + 'static> {
     inner: MaybeUninit<T>,
 }
 
-impl<T: Trace + 'static> NewCyclicWrapper<T> {
+impl<T: Trace> NewCyclicWrapper<T> {
     fn new() -> NewCyclicWrapper<T> {
         NewCyclicWrapper {
             inner: MaybeUninit::uninit(),
@@ -384,7 +384,7 @@ impl<T: Trace + 'static> NewCyclicWrapper<T> {
     }
 }
 
-unsafe impl<T: Trace + 'static> Trace for NewCyclicWrapper<T> {
+unsafe impl<T: Trace> Trace for NewCyclicWrapper<T> {
     fn trace(&self, ctx: &mut Context<'_>) {
         // SAFETY: NewCyclicWrapper is used only in new_cyclic and a traceable Cc instance is not constructed until the contents are initialized
         unsafe {
@@ -393,7 +393,7 @@ unsafe impl<T: Trace + 'static> Trace for NewCyclicWrapper<T> {
     }
 }
 
-impl<T: Trace + 'static> Finalize for NewCyclicWrapper<T> {
+impl<T: Trace> Finalize for NewCyclicWrapper<T> {
     fn finalize(&self) {
         // SAFETY: NewCyclicWrapper is used only in new_cyclic and a traceable Cc instance is not constructed until the contents are initialized
         unsafe {
@@ -402,7 +402,7 @@ impl<T: Trace + 'static> Finalize for NewCyclicWrapper<T> {
     }
 }
 
-impl<T: Trace + 'static> Drop for NewCyclicWrapper<T> {
+impl<T: Trace> Drop for NewCyclicWrapper<T> {
     fn drop(&mut self) {
         // SAFETY: NewCyclicWrapper is used only in new_cyclic and a traceable Cc instance is not constructed until the contents are initialized
         unsafe {

--- a/src/weak/mod.rs
+++ b/src/weak/mod.rs
@@ -135,7 +135,7 @@ impl<T: ?Sized + Trace> Weak<T> {
         self.weak_counter_marker().map_or(0, |wcm| wcm.counter() as u32)
     }
 
-    #[inline(always)]
+    #[inline]
     fn weak_counter_marker(&self) -> Option<&WeakCounterMarker> {
         Some(unsafe { &self.metadata?.as_ref().weak_counter_marker })
     }

--- a/src/weak/weak_counter_marker.rs
+++ b/src/weak/weak_counter_marker.rs
@@ -19,17 +19,17 @@ pub(crate) const MAX: u16 = !ACCESSIBLE_MASK; // First 15 bits to 1
 /// * `A` is `1` when the `Cc` is accessible, `0` otherwise
 /// * `B` is the weak counter
 #[derive(Clone, Debug)]
-pub(crate) struct WeakMetadata {
+pub(crate) struct WeakCounterMarker {
     weak_counter: Cell<u16>,
 }
 
 pub(crate) struct OverflowError;
 
-impl WeakMetadata {
+impl WeakCounterMarker {
     #[inline]
     #[must_use]
-    pub(crate) fn new(accessible: bool) -> WeakMetadata {
-        WeakMetadata {
+    pub(crate) fn new(accessible: bool) -> WeakCounterMarker {
+        WeakCounterMarker {
             weak_counter: Cell::new(if accessible {
                 INITIAL_VALUE_ACCESSIBLE
             } else {

--- a/tests/auto_collect.rs
+++ b/tests/auto_collect.rs
@@ -118,16 +118,16 @@ fn test_buffered_threshold_auto_collect() {
         _t: T,
     }
 
-    unsafe impl<T: 'static> Trace for Cyclic<T> {
+    unsafe impl<T> Trace for Cyclic<T> {
         fn trace(&self, ctx: &mut Context<'_>) {
             self.cyclic.trace(ctx);
         }
     }
 
-    impl<T: 'static> Finalize for Cyclic<T> {
+    impl<T> Finalize for Cyclic<T> {
     }
 
-    fn new<T: Default + 'static>() -> Cc<Cyclic<T>> {
+    fn new<T: Default>() -> Cc<Cyclic<T>> {
         let cc = Cc::new(Cyclic {
             cyclic: RefCell::new(None),
             _t: Default::default(),

--- a/tests/weak_upgrade_tests.rs
+++ b/tests/weak_upgrade_tests.rs
@@ -14,7 +14,7 @@ struct Ignored<T: Trace + 'static> {
     should_panic: bool,
 }
 
-impl<T: Trace + 'static> Drop for Ignored<T> {
+impl<T: Trace> Drop for Ignored<T> {
     fn drop(&mut self) {
         // This is safe to implement
         assert!(self.weak.upgrade().is_none());

--- a/tests/weak_upgrade_tests.rs
+++ b/tests/weak_upgrade_tests.rs
@@ -1,5 +1,5 @@
 #![cfg(not(miri))] // This test leaks memory, so it can't be run by Miri
-#![cfg(all(feature = "weak-ptr", feature = "derive"))]
+#![cfg(all(feature = "weak-ptrs", feature = "derive"))]
 //! This module tests that `Weak::upgrade` returns None when called in destructors while collecting.
 
 use std::cell::RefCell;

--- a/tests/weak_upgrade_tests.rs
+++ b/tests/weak_upgrade_tests.rs
@@ -57,7 +57,7 @@ fn cyclic_upgrade(should_panic: bool) {
     struct Allocated {
         #[rust_cc(ignore)]
         _ignored: Ignored<Allocated>,
-        cyclic: RefCell<Option<WeakableCc<Self>>>,
+        cyclic: RefCell<Option<Cc<Self>>>,
     }
 
     let cc1 = Cc::new_cyclic(|weak| Allocated {
@@ -101,6 +101,6 @@ fn cyclic_upgrade(should_panic: bool) {
     assert_eq!(should_panic, res.is_err());
 
     assert!(weak1.upgrade().is_none());
-    assert!(weak2.upgrade().is_none()); // This fails now |o|
+    assert!(weak2.upgrade().is_none());
     assert!(weak3.upgrade().is_none());
 }


### PR DESCRIPTION
* Update version to 0.4.0
* Improve the ergonomics of weak pointers
  * Remove `Weakable` and `WeakableCc`
  * Add `Weak::new()`
  * Rename `weak-ptr` feature to `weak-ptrs`
* Implement common traits like `Display`, `PartialEq`, `Eq`, `Hash`, etc.
* Code clean up and smaller improvements