### PR TITLE
Update to 0.6.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,16 +52,15 @@ Thus, marking should be done only:
 
 ## Writing tests
 
-Every unit test should start with a call to `tests::reset_state()` to make sure errors in other tests don't impact the current one.
-
-Also, functions marked as `pub(crate)` and used only in unit tests should have the `for_tests` suffix, like `Cc::new_for_tests`.
+Every unit test (which makes use of a part of the collector) should start with a call to `tests::reset_state()` to make
+sure errors in other tests don't impact the current one.
 
 ## Writing documentation
 
 Docs are always built with every feature enabled. This makes it easier to write and maintain the documentation.
 
-However, this also makes it more difficult to write examples, as those must pass CI even when some of the features they 
-require are disabled. As such, examples are marked as `ignore`d if a feature they need is missing:
+However, this also makes it more difficult to write examples, as those must pass CI even when a features they require is disabled.
+As such, examples are marked as `ignore`d if a feature they need is missing:
 ```rust
 #![cfg_attr(
     feature = "derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition.workspace = true
 members = ["derive"]
 
 [workspace.package]
-version = "0.5.0" # Also update in [dependencies.rust-cc-derive.version]
+version = "0.6.0" # Also update in [dependencies.rust-cc-derive.version]
 authors = ["fren_gor <goro@frengor.com>"]
 repository = "https://github.com/frengor/rust-cc"
 categories = ["memory-management", "no-std"]
@@ -49,7 +49,7 @@ std = ["slotmap?/std", "thiserror/std"]
 pedantic-debug-assertions = []
 
 [dependencies]
-rust-cc-derive = { path = "./derive", version = "=0.5.0", optional = true }
+rust-cc-derive = { path = "./derive", version = "=0.6.0", optional = true }
 slotmap = {  version = "1.0", optional = true }
 thiserror = { version = "1.0", package = "thiserror-core", default-features = false }
 

--- a/src/cc.rs
+++ b/src/cc.rs
@@ -2,7 +2,7 @@ use alloc::alloc::Layout;
 use alloc::rc::Rc;
 use core::cell::UnsafeCell;
 use core::marker::PhantomData;
-use core::mem;
+use core::mem::ManuallyDrop;
 use core::ops::Deref;
 use core::ptr::{self, drop_in_place, NonNull};
 use core::borrow::Borrow;
@@ -66,32 +66,52 @@ impl<T: Trace> Cc<T> {
         })
     }
 
-    /// Takes out the value inside a [`Cc`].
-    ///
-    /// # Panics
-    /// Panics if the [`Cc`] is not unique (see [`is_unique`]).
-    ///
-    /// [`is_unique`]: fn@Cc::is_unique
+    /// Returns the inner value, if the [`Cc`] has exactly one strong reference and the collector is not collecting, finalizing or dropping.
+    /// 
+    /// Otherwise, an [`Err`] is returned with the same [`Cc`] this method was called on.
+    /// 
+    /// This will succeed even if there are outstanding weak references.
     #[inline]
     #[track_caller]
-    pub fn into_inner(self) -> T {
-        assert!(self.is_unique(), "Cc<_> is not unique");
+    pub fn try_unwrap(self) -> Result<T, Self> {
+        let cc = ManuallyDrop::new(self); // Never drop the Cc
 
-        assert!(
-            !self.counter_marker().is_in_list_or_queue(),
-            "Cc<_> is being used by the collector and inner value cannot be taken out (this might have happen inside Trace, Finalize or Drop implementations)."
-        );
+        if cc.strong_count() != 1 {
+            // No need to access the state here
+            return Err(ManuallyDrop::into_inner(cc));
+        }
 
-        // Make sure self is not into POSSIBLE_CYCLES before deallocating
-        remove_from_list(self.inner.cast());
+        let res = try_state(|state| {
+            if state.is_collecting() || state.is_dropping() {
+                return None;
+            }
 
-        // SAFETY: self is unique and is not inside any list
-        unsafe {
-            let t = ptr::read(self.inner().get_elem());
-            let layout = self.inner().layout();
-            let _ = try_state(|state| cc_dealloc(self.inner, layout, state));
-            mem::forget(self); // Don't call drop on this Cc
-            t
+            #[cfg(feature = "finalization")]
+            if state.is_finalizing() {
+                // To make this method behave the same outside of collections, unwrapping while finalizing is prohibited
+                return None;
+            }
+
+            remove_from_list(cc.inner.cast());
+
+            // Disable upgrading weak ptrs
+            #[cfg(feature = "weak-ptrs")]
+            cc.inner().drop_metadata();
+            // There's no reason here to call CounterMarker::set_dropped, since the pointed value will not be dropped
+
+            // SAFETY: cc is unique and no weak pointer can be upgraded
+            let t = unsafe { ptr::read(cc.inner().get_elem()) };
+            let layout = cc.inner().layout();
+            // SAFETY: cc is unique, is not inside any list and no weak pointer can be upgraded
+            unsafe {
+                cc_dealloc(cc.inner, layout, state);
+            }
+            Some(t)
+        });
+
+        match res {
+            Ok(Some(t)) => Ok(t),
+            _ => Err(ManuallyDrop::into_inner(cc)),
         }
     }
 }

--- a/src/cc.rs
+++ b/src/cc.rs
@@ -129,12 +129,6 @@ impl<T: ?Sized + Trace> Cc<T> {
         self.counter_marker().counter() as u32
     }
 
-    /// Returns `true` if the strong reference count is `1`, `false` otherwise.
-    #[inline]
-    pub fn is_unique(&self) -> bool {
-        self.strong_count() == 1
-    }
-
     /// Makes the value in the managed allocation finalizable again.
     /// 
     /// # Panics


### PR DESCRIPTION
* Replace `Cc::into_inner` with `Cc::try_unwrap`, which now correctly handles weak pointers
* Remove `Cc::is_unique`
* Rework cleaners implementation