### PR TITLE
Update to 0.6.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ pedantic-debug-assertions = []
 [dependencies]
 rust-cc-derive = { path = "./derive", version = "=0.6.1", optional = true }
 slotmap = {  version = "1.0", optional = true }
-thiserror = { version = "1.0", package = "thiserror-core", default-features = false }
+thiserror = { version = "2.0", default-features = false }
 
 [dev-dependencies]
 iai-callgrind = "=0.12.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition.workspace = true
 members = ["derive"]
 
 [workspace.package]
-version = "0.6.1" # Also update in [dependencies.rust-cc-derive.version]
+version = "0.6.2" # Also update in [dependencies.rust-cc-derive.version]
 authors = ["fren_gor <goro@frengor.com>"]
 repository = "https://github.com/frengor/rust-cc"
 categories = ["memory-management", "no-std"]
@@ -49,7 +49,7 @@ std = ["slotmap?/std", "thiserror/std"]
 pedantic-debug-assertions = []
 
 [dependencies]
-rust-cc-derive = { path = "./derive", version = "=0.6.1", optional = true }
+rust-cc-derive = { path = "./derive", version = "=0.6.2", optional = true }
 slotmap = {  version = "1.0", optional = true }
 thiserror = { version = "2.0", default-features = false }
 

--- a/src/cc.rs
+++ b/src/cc.rs
@@ -13,7 +13,7 @@ use core::hash::{Hash, Hasher};
 use core::panic::{RefUnwindSafe, UnwindSafe};
 #[cfg(feature = "nightly")]
 use core::{
-    marker::SmartPointer,
+    marker::CoercePointee,
     ptr::{metadata, DynMetadata},
 };
 
@@ -28,7 +28,7 @@ use crate::weak::weak_counter_marker::WeakCounterMarker;
 /// A thread-local cycle collected pointer.
 ///
 /// See the [module-level documentation][`mod@crate`] for more details.
-#[cfg_attr(feature = "nightly", derive(SmartPointer))]
+#[cfg_attr(feature = "nightly", derive(CoercePointee))]
 #[repr(transparent)]
 pub struct Cc<#[cfg_attr(feature = "nightly", pointee)] T: ?Sized + Trace + 'static> {
     inner: NonNull<CcBox<T>>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,7 +131,7 @@ cleanable.clean();
 //! [`Sync`]: `std::marker::Sync`
 //! [`Rc`]: `std::rc::Rc`
 
-#![cfg_attr(feature = "nightly", feature(unsize, coerce_unsized, ptr_metadata, derive_smart_pointer))]
+#![cfg_attr(feature = "nightly", feature(unsize, coerce_unsized, ptr_metadata, derive_coerce_pointee))]
 #![cfg_attr(all(feature = "nightly", not(feature = "std")), feature(thread_local))] // no-std related unstable features
 #![cfg_attr(doc_auto_cfg, feature(doc_auto_cfg))]
 #![cfg_attr(not(feature = "std"), no_std)]

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -98,7 +98,7 @@ struct Foo<A: Trace + 'static, B: Trace + 'static> {
 ///     must be a subset of the [`Cc`] instances traced in the first one.  
 ///     Tracing can be detected using the [`state::is_tracing`] function. If it never returned `false` between two [`trace`] calls
 ///     on the same value, then they are part of the same tracing phase.
-///   * The [`trace`] implementation must not create, clone, dereference or drop any [`Cc`].
+///   * The [`trace`] implementation must not create, clone, move, dereference or drop any [`Cc`].
 ///   * If the implementing type implements [`Drop`], then the [`Drop::drop`] implementation must not create, clone, move, dereference, drop or call
 ///     any method on any [`Cc`] instance.
 ///


### PR DESCRIPTION
* Use thiserror 2.0 instead of thiserror-core
* Small update to the Trace documentation
* (nightly only) Update `derive(SmartPointer)` with `derive(CoercePointee)`
